### PR TITLE
AT-5109 Fix unauthorised git:// protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   },
   "gitHead": "ef12b4cdd358fd5dfcab16a3328dfacf9e636027",
   "dependencies": {
-    "utils": "git://github.com/wilsonpage/utils.git",
-    "event": "git://github.com/wilsonpage/event.git",
-    "mixin": "git://github.com/wilsonpage/mixin.git"
+    "utils": "github:wilsonpage/utils",
+    "event": "github:wilsonpage/event",
+    "mixin": "github:wilsonpage/mixin"
   },
   "devDependencies": {
     "buster": "~0.6.2",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.8",
     "grunt-buster": "~0.1.2",
-    "grunt-browserify": "git://github.com/wilsonpage/grunt-browserify.git",
+    "grunt-browserify": "github:wilsonpage/grunt-browserify",
     "grunt-contrib-uglify": "~0.1.2"
   }
 }


### PR DESCRIPTION
### Change protocol for dependencies

### Context:
* Github will stop supporting users connecting via SSH or `git://` on 15th March. 
* There was a brown out on 11th Jan. Example error on CI:
```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/wilsonpage/evt.git
npm ERR! 
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR! 
npm ERR! exited with error code: 128
```
* The FT App client is dependent on fruitmachine which is dependent on this base package. There will be a separate PR to update fruitmachine to use this fork.

#### In the PR
* Switch to `github:` shorthand, which (search for github: on https://docs.npmjs.com/cli/v8/commands/npm-install ) uses the git protocol and configuration on the machine npm is running on, which will be git+ssh for us and circleci.
* This approach was trialled by Rowan on the day of the brownout here - https://github.com/Financial-Times/ft-app/pull/1786
* This update will mean we can continue to build the webapp after 15th March
* Reference:
https://github.blog/2021-09-01-improving-git-protocol-security-github/